### PR TITLE
Add Kodi 14 autostart script and boot hook

### DIFF
--- a/hack/boot.sh
+++ b/hack/boot.sh
@@ -9,3 +9,4 @@ sh /data/hack/network.sh &
 sh /data/hack/telnet.sh &
 sh /data/hack/ftp.sh &
 sh /data/hack/plugins.sh &
+sh /data/hack/kodi_autostart.sh &

--- a/hack/kodi_autostart.sh
+++ b/hack/kodi_autostart.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# kodi_autostart.sh — Auto-start Kodi when SD card is detected at boot.
+# Scans /tmp/mnt/ for kodi.bin; UUID-independent.
+#
+# Place this file on the Boxee Box at: /data/hack/kodi_autostart.sh
+# Then add this line to /data/hack/boot.sh:
+#   sh /data/hack/kodi_autostart.sh &
+
+LOG=/tmp/kodi_autostart.log
+echo "$(date): kodi_autostart.sh started" > $LOG
+
+# Wait up to 60 seconds for the Kodi SD card to be automounted
+KODI_DIR=""
+for i in $(seq 1 60); do
+    for dir in /tmp/mnt/*/; do
+        if [ -x "${dir}kodi.bin" ]; then
+            KODI_DIR="${dir%/}"
+            break 2
+        fi
+    done
+    sleep 1
+done
+
+if [ -z "$KODI_DIR" ]; then
+    echo "$(date): kodi.bin not found in /tmp/mnt/ — Kodi SD card not present." >> $LOG
+    exit 1
+fi
+
+echo "$(date): Found Kodi at $KODI_DIR" >> $LOG
+
+# Let the system settle before killing Boxee
+sleep 3
+
+killall Boxee BoxeeLauncher BoxeeHal 2>/dev/null
+sleep 2
+
+cd "$KODI_DIR" || exit 1
+
+export HOME=/data
+export KODI_HOME="$KODI_DIR"
+export PYTHONHOME="$KODI_DIR/python2.7"
+export PYTHONPATH="$KODI_DIR/python2.7:$KODI_DIR/python2.7/lib-dynload"
+export LD_LIBRARY_PATH="$KODI_DIR/lib:$KODI_DIR:/opt/local/lib:/opt/boxee/lib:$LD_LIBRARY_PATH"
+
+echo "$(date): Starting Kodi from $KODI_DIR (HOME=$HOME)" >> $LOG
+exec ./kodi.bin >> $LOG 2>&1


### PR DESCRIPTION
## Summary

- Adds `hack/kodi_autostart.sh`: polls `/tmp/mnt/` for `kodi.bin`, kills Boxee/BoxeeLauncher/BoxeeHal, sets required environment variables, and launches Kodi 14.2 (Helix) from a USB stick or SD card
- Updates `hack/boot.sh` to invoke `kodi_autostart.sh` at boot

## Why

Kodi 14.2 (Helix) for Intel CE4100 can run on the Boxee Box, but requires:
1. Waiting for storage to mount (SD card goes through an Alcor Micro USB IC, mounts asynchronously)
2. Killing the Boxee UI stack (Boxee, BoxeeLauncher, BoxeeHal compete for display/audio hardware)
3. Setting correct runtime env for Kodi's bundled Python 2.7 and shared libs (`HOME`, `KODI_HOME`, `PYTHONHOME`, `PYTHONPATH`, `LD_LIBRARY_PATH`)

The script is UUID-independent — works regardless of which slot or what filesystem UUID the media has.

## Test plan

- [ ] Place `kodi_autostart.sh` at `/data/hack/kodi_autostart.sh` on a Boxee Box with Boxee+Hacks installed
- [ ] Verify `boot.sh` has the autostart line
- [ ] Insert Kodi SD card or USB stick before booting
- [ ] Reboot — Kodi starts automatically after ~60–90 seconds
- [ ] Check `/tmp/kodi_autostart.log` for boot status

Full setup guide: https://github.com/yoavmagor/boxee-2026-yoavm

🤖 Generated with [Claude Code](https://claude.ai/code)